### PR TITLE
Add HTTP health endpoint and enhance chat client reliability

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -176,10 +176,12 @@
             display: none; /* Initially hidden */
             padding: 20px;
             background-color: var(--sidebar-color);
+            align-items: center;
+            gap: 10px;
         }
 
         #chat-form input {
-            width: 100%;
+            flex-grow: 1;
             padding: 15px;
             border: none;
             border-radius: 8px;
@@ -191,6 +193,15 @@
         #chat-form input:focus {
             outline: none;
             box-shadow: 0 0 15px var(--accent-color);
+        }
+
+        #chat-form button {
+            padding: 12px 16px;
+            border: none;
+            border-radius: 8px;
+            background-color: var(--accent-color);
+            color: var(--bg-color);
+            cursor: pointer;
         }
     </style>
 </head>
@@ -216,104 +227,166 @@
             </div>
             <form id="chat-form">
                 <input type="text" id="message-input" placeholder="Type your message..." autocomplete="off">
+                <button type="button" id="emoji-button">😊</button>
+                <button type="button" id="file-button">📎</button>
+                <button type="submit" id="send-button">Send</button>
+                <input type="file" id="file-input" style="display:none" />
             </form>
         </main>
     </div>
-
+    <script src="https://cdn.jsdelivr.net/npm/emoji-button@latest/dist/index.min.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            // !!! IMPORTANT: Change this URL to your Render app URL when deployed !!!
             const WEBSOCKET_URL = 'wss://chat-i8zf.onrender.com/live-chat';
-            
+
             const userList = document.getElementById('user-list');
             const chatWindow = document.getElementById('chat-window');
             const messageInput = document.getElementById('message-input');
             const chatForm = document.getElementById('chat-form');
             const currentChatUserHeader = document.getElementById('current-chat-user');
             const noUserSelectedView = document.getElementById('no-user-selected');
+            const fileInput = document.getElementById('file-input');
+            const emojiButton = document.getElementById('emoji-button');
+            const fileButton = document.getElementById('file-button');
 
-            let selectedUserId = null;
-            let chats = {}; // Store message history for each user
+            const picker = new EmojiButton();
+            emojiButton.addEventListener('click', () => picker.togglePicker(emojiButton));
+            picker.on('emoji', emoji => {
+                messageInput.value += emoji;
+                messageInput.focus();
+            });
 
-            const socket = new WebSocket(WEBSOCKET_URL);
-
-            socket.onopen = () => {
-                console.log('Connected to WebSocket server as Admin.');
-                // Identify as admin
-                socket.send(JSON.stringify({ type: 'admin-init' }));
-            };
-
-            socket.onmessage = (event) => {
-                const data = JSON.parse(event.data);
-                
-                switch (data.type) {
-                    case 'user-connected':
-                        addUserToList(data.id);
-                        break;
-                    case 'user-disconnected':
-                        removeUserFromList(data.id);
-                        break;
-                    case 'message':
-                        handleIncomingMessage(data);
-                        break;
-                    case 'all-users':
-                        data.users.forEach(userId => addUserToList(userId));
-                        break;
+            fileButton.addEventListener('click', () => fileInput.click());
+            fileInput.addEventListener('change', () => {
+                const file = fileInput.files[0];
+                if (file && selectedUserId) {
+                    sendFile(file);
                 }
-            };
+                fileInput.value = '';
+            });
 
-            socket.onclose = () => {
-                console.log('WebSocket connection closed.');
-                alert('Connection lost. Please refresh the page.');
-            };
-            
-            socket.onerror = (error) => {
-                console.error('WebSocket Error:', error);
-                alert('Could not connect to the chat server.');
-            };
+            messageInput.addEventListener('paste', (e) => {
+                const items = e.clipboardData.items;
+                for (const item of items) {
+                    if (item.kind === 'file') {
+                        const file = item.getAsFile();
+                        if (file && selectedUserId) {
+                            sendFile(file);
+                        }
+                        e.preventDefault();
+                    }
+                }
+            });
+
+            let socket;
+            let reconnectDelay = 1000;
+            let selectedUserId = null;
+            let chats = {};
+
+            function connect() {
+                socket = new WebSocket(WEBSOCKET_URL);
+
+                socket.onopen = () => {
+                    reconnectDelay = 1000;
+                    socket.send(JSON.stringify({ type: 'admin-init' }));
+                    startHeartbeat();
+                };
+
+                socket.onmessage = (event) => {
+                    const data = JSON.parse(event.data);
+                    switch (data.type) {
+                        case 'user-connected':
+                            addUserToList(data.id, data.name, data.ip);
+                            break;
+                        case 'user-disconnected':
+                            removeUserFromList(data.id);
+                            break;
+                        case 'user-renamed':
+                            renameUser(data.id, data.name);
+                            break;
+                        case 'message':
+                            handleIncomingMessage(data);
+                            break;
+                        case 'file':
+                            handleIncomingFile(data);
+                            break;
+                        case 'all-users':
+                            data.users.forEach(u => addUserToList(u.id, u.name, u.ip));
+                            break;
+                        case 'pong':
+                            break;
+                    }
+                };
+
+                socket.onclose = () => {
+                    stopHeartbeat();
+                    setTimeout(connect, reconnectDelay);
+                    reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+                };
+
+                socket.onerror = () => {
+                    socket.close();
+                };
+            }
+
+            connect();
+
+            let heartbeatInterval;
+            function startHeartbeat() {
+                heartbeatInterval = setInterval(() => {
+                    if (socket.readyState === WebSocket.OPEN) {
+                        socket.send(JSON.stringify({ type: 'ping' }));
+                    }
+                }, 30000);
+            }
+
+            function stopHeartbeat() {
+                clearInterval(heartbeatInterval);
+            }
 
             chatForm.addEventListener('submit', (e) => {
                 e.preventDefault();
                 const messageText = messageInput.value.trim();
-                if (messageText && selectedUserId) {
-                    const message = {
-                        type: 'message',
-                        to: selectedUserId,
-                        text: messageText
-                    };
-                    socket.send(JSON.stringify(message));
-                    addMessageToChat(selectedUserId, 'sent', messageText);
+                if (messageText && selectedUserId && socket.readyState === WebSocket.OPEN) {
+                    socket.send(JSON.stringify({ type: 'message', to: selectedUserId, text: messageText }));
+                    addMessageToChat(selectedUserId, 'sent', linkify(messageText));
                     messageInput.value = '';
                 }
             });
 
-            function addUserToList(userId) {
-                if (document.getElementById(`user-${userId}`)) return; // Already exists
-                
-                const userItem = document.createElement('li');
-                userItem.id = `user-${userId}`;
-                userItem.textContent = `User: ${userId.substring(0, 8)}`;
-                userItem.dataset.userId = userId;
-                
-                userItem.addEventListener('click', () => {
-                    selectUser(userId);
-                });
-                
-                userList.appendChild(userItem);
-                
-                if (!chats[userId]) {
-                    chats[userId] = [];
-                }
+            function sendFile(file) {
+                const reader = new FileReader();
+                reader.onload = () => {
+                    const base64 = reader.result.split(',')[1];
+                    socket.send(JSON.stringify({
+                        type: 'file',
+                        to: selectedUserId,
+                        name: file.name,
+                        mime: file.type,
+                        data: base64
+                    }));
+                    addFileMessage(selectedUserId, 'sent', file.name, file.type, base64);
+                };
+                reader.readAsDataURL(file);
             }
 
-            function removeUserFromList(userId) {
-                const userItem = document.getElementById(`user-${userId}`);
-                if (userItem) {
-                    userItem.style.animation = 'slideOutToLeft 0.5s forwards';
-                    setTimeout(() => userItem.remove(), 500);
-                }
-                
-                if (selectedUserId === userId) {
+            function addUserToList(id, name, ip) {
+                if (document.getElementById(`user-${id}`)) return;
+                const userItem = document.createElement('li');
+                userItem.id = `user-${id}`;
+                userItem.dataset.userId = id;
+                userItem.dataset.ip = ip;
+                userItem.textContent = `${name} (${ip})`;
+                userItem.addEventListener('click', () => selectUser(id));
+                userList.appendChild(userItem);
+                chats[id] = chats[id] || [];
+            }
+
+            function removeUserFromList(id) {
+                const userItem = document.getElementById(`user-${id}`);
+                if (userItem) userItem.remove();
+                delete chats[id];
+                if (selectedUserId === id) {
                     selectedUserId = null;
                     chatWindow.innerHTML = '';
                     chatWindow.style.display = 'none';
@@ -323,51 +396,55 @@
                 }
             }
 
-            function selectUser(userId) {
+            function renameUser(id, name) {
+                const userItem = document.getElementById(`user-${id}`);
+                if (userItem) {
+                    userItem.textContent = `${name} (${userItem.dataset.ip})`;
+                }
+            }
+
+            function selectUser(id) {
                 if (selectedUserId) {
                     document.getElementById(`user-${selectedUserId}`)?.classList.remove('active');
                 }
-                selectedUserId = userId;
-                document.getElementById(`user-${userId}`).classList.add('active');
-                
-                currentChatUserHeader.textContent = `Chatting with User: ${userId.substring(0, 8)}`;
+                selectedUserId = id;
+                document.getElementById(`user-${id}`).classList.add('active');
+                currentChatUserHeader.textContent = `Chatting with ${document.getElementById(`user-${id}`).textContent}`;
                 noUserSelectedView.style.display = 'none';
                 chatWindow.style.display = 'block';
-                chatForm.style.display = 'block';
-
-                loadChatHistory(userId);
+                chatForm.style.display = 'flex';
+                loadChatHistory(id);
             }
 
-            function loadChatHistory(userId) {
+            function loadChatHistory(id) {
                 chatWindow.innerHTML = '';
-                chats[userId].forEach(msg => {
-                     const messageElement = document.createElement('div');
-                    messageElement.classList.add('message', msg.direction);
-                    messageElement.textContent = msg.text;
-                    chatWindow.appendChild(messageElement);
+                (chats[id] || []).forEach(msg => {
+                    if (msg.type === 'file') {
+                        appendFileMessage(msg.direction, msg.name, msg.mime, msg.data);
+                    } else {
+                        appendMessage(msg.direction, msg.html);
+                    }
                 });
                 chatWindow.scrollTop = chatWindow.scrollHeight;
             }
 
             function handleIncomingMessage(message) {
                 const fromUserId = message.from;
-                addMessageToChat(fromUserId, 'received', message.text);
+                addMessageToChat(fromUserId, 'received', linkify(message.text));
             }
 
-            function addMessageToChat(userId, direction, text) {
-                // Save to history
-                if (!chats[userId]) chats[userId] = [];
-                chats[userId].push({ direction, text });
-                
-                // If this is the currently active chat, display it
+            function handleIncomingFile(message) {
+                const fromUserId = message.from;
+                addFileMessage(fromUserId, 'received', message.name, message.mime, message.data);
+            }
+
+            function addMessageToChat(userId, direction, html) {
+                chats[userId] = chats[userId] || [];
+                chats[userId].push({ direction, html });
+
                 if (userId === selectedUserId) {
-                    const messageElement = document.createElement('div');
-                    messageElement.classList.add('message', direction);
-                    messageElement.textContent = text;
-                    chatWindow.appendChild(messageElement);
-                    chatWindow.scrollTop = chatWindow.scrollHeight;
+                    appendMessage(direction, html);
                 } else {
-                    // Optional: Add a notification dot to the user in the list
                     const userItem = document.getElementById(`user-${userId}`);
                     if (userItem && !userItem.querySelector('.notification-dot')) {
                         const dot = document.createElement('span');
@@ -375,6 +452,48 @@
                         userItem.appendChild(dot);
                     }
                 }
+            }
+
+            function addFileMessage(userId, direction, name, mime, data) {
+                chats[userId] = chats[userId] || [];
+                chats[userId].push({ type: 'file', direction, name, mime, data });
+                if (userId === selectedUserId) {
+                    appendFileMessage(direction, name, mime, data);
+                }
+            }
+
+            function appendMessage(direction, html) {
+                const messageElement = document.createElement('div');
+                messageElement.classList.add('message', direction);
+                messageElement.innerHTML = html;
+                chatWindow.appendChild(messageElement);
+                chatWindow.scrollTop = chatWindow.scrollHeight;
+            }
+
+            function appendFileMessage(direction, name, mime, data) {
+                const blob = b64toBlob(data, mime);
+                const url = URL.createObjectURL(blob);
+                let html;
+                if (mime.startsWith('image/')) {
+                    html = `<img src="${url}" alt="${name}" style="max-width:100%;">`;
+                } else {
+                    html = `<a href="${url}" download="${name}" target="_blank">${name}</a>`;
+                }
+                appendMessage(direction, html);
+            }
+
+            function linkify(text) {
+                return text.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank">$1</a>');
+            }
+
+            function b64toBlob(base64, mime) {
+                const byteChars = atob(base64);
+                const byteNumbers = new Array(byteChars.length);
+                for (let i = 0; i < byteChars.length; i++) {
+                    byteNumbers[i] = byteChars.charCodeAt(i);
+                }
+                const byteArray = new Uint8Array(byteNumbers);
+                return new Blob([byteArray], { type: mime });
             }
         });
     </script>

--- a/server.js
+++ b/server.js
@@ -1,16 +1,53 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
 const { WebSocketServer } = require('ws');
 const { v4: uuidv4 } = require('uuid');
 
 const PORT = process.env.PORT || 8080;
-const wss = new WebSocketServer({ port: PORT });
+
+// Basic HTTP server for health checks and serving static files
+const server = http.createServer((req, res) => {
+    if (req.url === '/' || req.url === '/healthz') {
+        console.log(`[${new Date().toISOString()}] Received keep-alive ping`);
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        return res.end('OK');
+    }
+
+    const fileMap = {
+        '/admin': 'admin.html',
+        '/user': 'user.html',
+    };
+
+    const fileName = fileMap[req.url] || req.url.slice(1);
+    if (fileName) {
+        const filePath = path.join(__dirname, fileName);
+        return fs.readFile(filePath, (err, data) => {
+            if (err) {
+                res.writeHead(404);
+                return res.end('Not found');
+            }
+            res.writeHead(200);
+            res.end(data);
+        });
+    }
+
+    res.writeHead(404);
+    res.end();
+});
+
+// WebSocket server mounted on the HTTP server
+const wss = new WebSocketServer({ server, path: '/live-chat' });
 
 let admin = null;
-const users = new Map(); // Using a Map to store user WebSocket connections by ID
+const users = new Map(); // id -> { ws, name, ip }
 
-console.log(`WebSocket server is running on port ${PORT}`);
+wss.on('connection', (ws, req) => {
+    ws.isAlive = true;
+    ws.on('pong', () => { ws.isAlive = true; });
 
-wss.on('connection', (ws) => {
-    console.log('Client connected.');
+    const ip = req.headers['x-forwarded-for']?.split(',')[0].trim() || req.socket.remoteAddress;
+    console.log('Client connected.', ip);
 
     ws.on('message', (message) => {
         let data;
@@ -25,39 +62,107 @@ wss.on('connection', (ws) => {
             case 'admin-init':
                 console.log('Admin has connected.');
                 admin = ws;
-                // Send the list of currently connected users to the admin
-                admin.send(JSON.stringify({ type: 'all-users', users: Array.from(users.keys()) }));
+                admin.send(
+                    JSON.stringify({
+                        type: 'all-users',
+                        users: Array.from(users.entries()).map(([id, info]) => ({
+                            id,
+                            name: info.name,
+                            ip: info.ip,
+                        })),
+                    })
+                );
                 break;
 
             case 'user-init':
                 const userId = uuidv4();
-                ws.id = userId; // Assign a unique ID to the user's connection
-                users.set(userId, ws);
-                console.log(`User connected with ID: ${userId}`);
-                // Notify admin if connected
+                ws.id = userId;
+                ws.name = data.name || `User-${userId.substring(0, 8)}`;
+                ws.ip = ip;
+                users.set(userId, { ws, name: ws.name, ip });
+                console.log(`User connected with ID: ${userId} (${ws.name}) from ${ip}`);
                 if (admin && admin.readyState === admin.OPEN) {
-                    admin.send(JSON.stringify({ type: 'user-connected', id: userId }));
+                    admin.send(
+                        JSON.stringify({
+                            type: 'user-connected',
+                            id: userId,
+                            name: ws.name,
+                            ip,
+                        })
+                    );
+                }
+                ws.send(JSON.stringify({ type: 'user-id', id: userId }));
+                break;
+
+            case 'rename':
+                if (ws.id && users.has(ws.id)) {
+                    ws.name = data.name || ws.name;
+                    const info = users.get(ws.id);
+                    info.name = ws.name;
+                    if (admin && admin.readyState === admin.OPEN) {
+                        admin.send(
+                            JSON.stringify({
+                                type: 'user-renamed',
+                                id: ws.id,
+                                name: ws.name,
+                            })
+                        );
+                    }
                 }
                 break;
-                
+
             case 'message':
-                // Message from admin to a specific user
                 if (ws === admin) {
-                    const recipient = users.get(data.to);
+                    const recipient = users.get(data.to)?.ws;
                     if (recipient && recipient.readyState === recipient.OPEN) {
-                        recipient.send(JSON.stringify({ type: 'message', text: data.text }));
+                        recipient.send(
+                            JSON.stringify({ type: 'message', text: data.text })
+                        );
                     }
-                }
-                // Message from a user to the admin
-                else if (ws.id && users.has(ws.id)) {
+                } else if (ws.id && users.has(ws.id)) {
                     if (admin && admin.readyState === admin.OPEN) {
-                        admin.send(JSON.stringify({
-                            type: 'message',
-                            from: ws.id,
-                            text: data.text
-                        }));
+                        admin.send(
+                            JSON.stringify({
+                                type: 'message',
+                                from: ws.id,
+                                text: data.text,
+                            })
+                        );
                     }
                 }
+                break;
+
+            case 'file':
+                if (ws === admin) {
+                    const recipient = users.get(data.to)?.ws;
+                    if (recipient && recipient.readyState === recipient.OPEN) {
+                        recipient.send(
+                            JSON.stringify({
+                                type: 'file',
+                                name: data.name,
+                                mime: data.mime,
+                                data: data.data,
+                            })
+                        );
+                    }
+                } else if (ws.id && users.has(ws.id)) {
+                    if (admin && admin.readyState === admin.OPEN) {
+                        admin.send(
+                            JSON.stringify({
+                                type: 'file',
+                                from: ws.id,
+                                name: data.name,
+                                mime: data.mime,
+                                data: data.data,
+                            })
+                        );
+                    }
+                }
+                break;
+
+            case 'ping':
+                console.log('Received ping');
+                ws.send(JSON.stringify({ type: 'pong' }));
                 break;
 
             default:
@@ -72,16 +177,34 @@ wss.on('connection', (ws) => {
         } else if (ws.id && users.has(ws.id)) {
             console.log(`User ${ws.id} disconnected.`);
             users.delete(ws.id);
-            // Notify admin if connected
             if (admin && admin.readyState === admin.OPEN) {
-                admin.send(JSON.stringify({ type: 'user-disconnected', id: ws.id }));
+                admin.send(
+                    JSON.stringify({ type: 'user-disconnected', id: ws.id })
+                );
             }
         } else {
             console.log('An unidentified client disconnected.');
         }
     });
-    
+
     ws.on('error', (error) => {
         console.error('WebSocket error:', error);
     });
 });
+
+// Heartbeat to keep connections alive
+const interval = setInterval(() => {
+    wss.clients.forEach((ws) => {
+        if (!ws.isAlive) return ws.terminate();
+        ws.isAlive = false;
+        ws.ping();
+        console.log('Sent ping to client');
+    });
+}, 30000);
+
+wss.on('close', () => clearInterval(interval));
+
+server.listen(PORT, () => {
+    console.log(`HTTP/WebSocket server listening on port ${PORT}`);
+});
+

--- a/user.html
+++ b/user.html
@@ -63,6 +63,10 @@
             border-top-right-radius: 20px;
             text-align: center;
             position: relative;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
         }
         
         #status-indicator {
@@ -145,6 +149,8 @@
             display: flex;
             padding: 20px;
             border-top: 1px solid var(--input-bg);
+            align-items: center;
+            gap: 10px;
         }
 
         #message-input {
@@ -155,15 +161,14 @@
             color: var(--text-color);
             border-radius: 25px;
             font-size: 1em;
-            margin-right: 10px;
         }
-        
+
         #message-input:focus {
             outline: none;
             box-shadow: 0 0 10px var(--accent-color);
         }
 
-        #send-button {
+        #chat-form button {
             padding: 12px 20px;
             border: none;
             background-color: var(--accent-color);
@@ -173,10 +178,19 @@
             font-weight: 600;
             transition: transform 0.2s, background-color 0.3s;
         }
-        
-        #send-button:hover {
+
+        #chat-form button:hover {
             transform: scale(1.05);
             background-color: #62c3d4;
+        }
+
+        .chat-header button {
+            border: none;
+            background: var(--accent-color);
+            color: var(--bg-color);
+            padding: 6px 10px;
+            border-radius: 8px;
+            cursor: pointer;
         }
     </style>
 </head>
@@ -186,77 +200,187 @@
         <div class="chat-header">
             <span id="status-indicator"></span>
             <h3>Live Support</h3>
+            <button id="rename-button" type="button">✏️</button>
         </div>
         <div id="chat-messages">
             <!-- Messages will appear here -->
         </div>
         <form id="chat-form">
             <input type="text" id="message-input" placeholder="Ask us anything..." autocomplete="off">
+            <button type="button" id="emoji-button">😊</button>
+            <button type="button" id="file-button">📎</button>
             <button type="submit" id="send-button">Send</button>
+            <input type="file" id="file-input" style="display:none" />
         </form>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/emoji-button@latest/dist/index.min.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            // !!! IMPORTANT: Change this URL to your Render app URL when deployed !!!
             const WEBSOCKET_URL = 'wss://chat-i8zf.onrender.com/live-chat';
-            
+
             const messagesContainer = document.getElementById('chat-messages');
             const messageForm = document.getElementById('chat-form');
             const messageInput = document.getElementById('message-input');
             const statusIndicator = document.getElementById('status-indicator');
+            const emojiButton = document.getElementById('emoji-button');
+            const fileButton = document.getElementById('file-button');
+            const fileInput = document.getElementById('file-input');
+            const renameButton = document.getElementById('rename-button');
 
-            const socket = new WebSocket(WEBSOCKET_URL);
+            const picker = new EmojiButton();
+            emojiButton.addEventListener('click', () => picker.togglePicker(emojiButton));
+            picker.on('emoji', emoji => {
+                messageInput.value += emoji;
+                messageInput.focus();
+            });
 
-            socket.onopen = () => {
-                console.log('Connected to WebSocket server.');
-                statusIndicator.classList.add('connected');
-                // Identify as a user
-                socket.send(JSON.stringify({ type: 'user-init' }));
-                addMessage('received', 'Welcome! How can we help you today?');
-            };
-
-            socket.onmessage = (event) => {
-                const data = JSON.parse(event.data);
-                if (data.type === 'message') {
-                    addMessage('received', data.text);
+            fileButton.addEventListener('click', () => fileInput.click());
+            fileInput.addEventListener('change', () => {
+                const file = fileInput.files[0];
+                if (file) {
+                    sendFile(file);
                 }
-            };
-            
-            socket.onclose = () => {
-                console.log('WebSocket connection closed.');
-                statusIndicator.classList.remove('connected');
-                addMessage('received', 'Connection to support has been lost. Please refresh.');
-            };
+                fileInput.value = '';
+            });
 
-socket.onerror = (error) => {
-    console.error('WebSocket Error:', error);
-    statusIndicator.classList.remove('connected');
-    addMessage('received', 'Could not connect to the support server.'); // שים לב שהנתיב נמחק
-};
+            messageInput.addEventListener('paste', (e) => {
+                const items = e.clipboardData.items;
+                for (const item of items) {
+                    if (item.kind === 'file') {
+                        const file = item.getAsFile();
+                        if (file) {
+                            sendFile(file);
+                        }
+                        e.preventDefault();
+                    }
+                }
+            });
+
+            let socket;
+            let reconnectDelay = 1000;
+            let currentName = prompt('Enter your name:', 'Guest') || 'Guest';
+
+            renameButton.addEventListener('click', () => {
+                const newName = prompt('Enter new name:', currentName);
+                if (newName && newName !== currentName) {
+                    currentName = newName;
+                    if (socket && socket.readyState === WebSocket.OPEN) {
+                        socket.send(JSON.stringify({ type: 'rename', name: currentName }));
+                    }
+                }
+            });
+
+            function connect() {
+                socket = new WebSocket(WEBSOCKET_URL);
+
+                socket.onopen = () => {
+                    reconnectDelay = 1000;
+                    statusIndicator.classList.add('connected');
+                    socket.send(JSON.stringify({ type: 'user-init', name: currentName }));
+                    addMessage('received', 'Welcome! How can we help you today?');
+                    startHeartbeat();
+                };
+
+                socket.onmessage = (event) => {
+                    const data = JSON.parse(event.data);
+                    if (data.type === 'message') {
+                        addMessage('received', linkify(data.text));
+                    } else if (data.type === 'file') {
+                        addFileMessage('received', data.name, data.mime, data.data);
+                    }
+                };
+
+                socket.onclose = () => {
+                    statusIndicator.classList.remove('connected');
+                    stopHeartbeat();
+                    addMessage('received', 'Connection lost. Reconnecting...');
+                    setTimeout(connect, reconnectDelay);
+                    reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+                };
+
+                socket.onerror = () => {
+                    socket.close();
+                };
+            }
+
+            connect();
+
+            let heartbeatInterval;
+            function startHeartbeat() {
+                heartbeatInterval = setInterval(() => {
+                    if (socket.readyState === WebSocket.OPEN) {
+                        socket.send(JSON.stringify({ type: 'ping' }));
+                    }
+                }, 30000);
+            }
+
+            function stopHeartbeat() {
+                clearInterval(heartbeatInterval);
+            }
+
             messageForm.addEventListener('submit', (e) => {
                 e.preventDefault();
                 const messageText = messageInput.value.trim();
-                if (messageText) {
-                    addMessage('sent', messageText);
+                if (messageText && socket.readyState === WebSocket.OPEN) {
+                    addMessage('sent', linkify(messageText));
                     socket.send(JSON.stringify({ type: 'message', text: messageText }));
                     messageInput.value = '';
                 }
             });
 
-            function addMessage(type, text) {
+            function sendFile(file) {
+                const reader = new FileReader();
+                reader.onload = () => {
+                    const base64 = reader.result.split(',')[1];
+                    socket.send(JSON.stringify({
+                        type: 'file',
+                        name: file.name,
+                        mime: file.type,
+                        data: base64
+                    }));
+                    addFileMessage('sent', file.name, file.type, base64);
+                };
+                reader.readAsDataURL(file);
+            }
+
+            function addMessage(type, html) {
                 const messageDiv = document.createElement('div');
                 messageDiv.classList.add('message', type);
 
                 const bubbleDiv = document.createElement('div');
                 bubbleDiv.classList.add('message-bubble');
-                bubbleDiv.textContent = text;
-                
+                bubbleDiv.innerHTML = html;
+
                 messageDiv.appendChild(bubbleDiv);
                 messagesContainer.appendChild(messageDiv);
-                
-                // Scroll to the bottom
                 messagesContainer.scrollTop = messagesContainer.scrollHeight;
+            }
+
+            function addFileMessage(type, name, mime, data) {
+                const blob = b64toBlob(data, mime);
+                const url = URL.createObjectURL(blob);
+                let html;
+                if (mime.startsWith('image/')) {
+                    html = `<img src="${url}" alt="${name}" style="max-width:100%;">`;
+                } else {
+                    html = `<a href="${url}" download="${name}" target="_blank">${name}</a>`;
+                }
+                addMessage(type, html);
+            }
+
+            function linkify(text) {
+                return text.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank">$1</a>');
+            }
+
+            function b64toBlob(base64, mime) {
+                const byteChars = atob(base64);
+                const byteNumbers = new Array(byteChars.length);
+                for (let i = 0; i < byteChars.length; i++) {
+                    byteNumbers[i] = byteChars.charCodeAt(i);
+                }
+                const byteArray = new Uint8Array(byteNumbers);
+                return new Blob([byteArray], { type: mime });
             }
         });
     </script>


### PR DESCRIPTION
## Summary
- add Node HTTP server with `/` and `/healthz` for 200 OK responses and ping logging
- support file/emoji sending, name changes, and auto reconnect with heartbeat in admin and user chats
- expose user IP and keep WebSocket connections alive via server/client pings

## Testing
- `node server.js`


------
https://chatgpt.com/codex/tasks/task_e_68c121bb9054832387c84ae5fe588697